### PR TITLE
Use process.cwd() as base of js/css paths

### DIFF
--- a/js/impressionist.js
+++ b/js/impressionist.js
@@ -1056,7 +1056,7 @@
             // Aaannd then we reload impress and put the impressionist bits right back to where they were
             impress().init();
             var script = impressionist().util.loadJavaScript(
-                process.resourcesPath + "/../../../../js/impressionist.js", function(){
+                process.cwd() + "/js/impressionist.js", function(){
                     impressionist().gc.pushElement(script); // The circle of life :-)
                     impressionist().util.triggerEvent(document, "impressionist:init", {}) 
                 });
@@ -1108,7 +1108,7 @@
 (function ( document, window ) {
     'use strict';
     // Just load it ASAP. No need to wait for impressionist:init
-    var link = impressionist().util.loadCss(process.resourcesPath + "/../../../../css/impressionist.css");
+    var link = impressionist().util.loadCss(process.cwd() + "/css/impressionist.css");
     impressionist().gc.pushElement(link);
 
 })(document, window);
@@ -1358,7 +1358,7 @@
         var html = '<div id="tinymce-toolbar"></div>';
         toolbar = impressionist().util.makeDomElement(html);
         gc.appendChild(document.body, toolbar);
-        script = impressionist().util.loadJavaScript(process.resourcesPath + "/../../../tinymce/tinymce.js", tinymceInit);
+        script = impressionist().util.loadJavaScript(process.cwd() + "/node_modules/tinymce/tinymce.js", tinymceInit);
         impressionist().gc.pushElement(script);
     });
 

--- a/main.js
+++ b/main.js
@@ -45,7 +45,7 @@ app.on('activate', function () {
 
 function loadImpressionist () {
     return `var script = document.createElement("script");
-    script.src = process.resourcesPath + "/../../../../js/impressionist.js";
+    script.src = process.cwd() + "/js/impressionist.js";
     script.type = "text/javascript";
     script.onload = function(){
         impressionist().gc.pushElement(script)

--- a/src/plugins/electron/electron.js
+++ b/src/plugins/electron/electron.js
@@ -25,7 +25,7 @@
             // Aaannd then we reload impress and put the impressionist bits right back to where they were
             impress().init();
             var script = impressionist().util.loadJavaScript(
-                process.resourcesPath + "/../../../../js/impressionist.js", function(){
+                process.cwd() + "/js/impressionist.js", function(){
                     impressionist().gc.pushElement(script); // The circle of life :-)
                     impressionist().util.triggerEvent(document, "impressionist:init", {}) 
                 });

--- a/src/plugins/loadcss/loadcss.js
+++ b/src/plugins/loadcss/loadcss.js
@@ -7,7 +7,7 @@
 (function ( document, window ) {
     'use strict';
     // Just load it ASAP. No need to wait for impressionist:init
-    var link = impressionist().util.loadCss(process.resourcesPath + "/../../../../css/impressionist.css");
+    var link = impressionist().util.loadCss(process.cwd() + "/css/impressionist.css");
     impressionist().gc.pushElement(link);
 
 })(document, window);

--- a/src/plugins/tinymce/tinymce.js
+++ b/src/plugins/tinymce/tinymce.js
@@ -55,7 +55,7 @@
         var html = '<div id="tinymce-toolbar"></div>';
         toolbar = impressionist().util.makeDomElement(html);
         gc.appendChild(document.body, toolbar);
-        script = impressionist().util.loadJavaScript(process.resourcesPath + "/../../../tinymce/tinymce.js", tinymceInit);
+        script = impressionist().util.loadJavaScript(process.cwd() + "/node_modules/tinymce/tinymce.js", tinymceInit);
         impressionist().gc.pushElement(script);
     });
 


### PR DESCRIPTION
Using process.resourcesPath as the base of js/css paths does not work on macOS/darwin because the macOS app bundle means that process.resourcesPath is two levels lower than it (apparently) is on Linux. I do not know where the resourcesPath falls in a Windows build, but using process.cwd() should make it work cross-platform.

Note that process.cwd() returns the base of the impressionist folder hierarchy, in my case /Users/eric/Developer/impressionist. This eliminates the many levels of '/../../../..' needed when using process.resourcesPath. I assume other platforms return the same cwd but am not able to test this.